### PR TITLE
Use token to sign plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: grafana/plugin-actions/build-plugin@release
         # Uncomment to enable plugin signing
         # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
-        #with:
+        with:
         # Make sure to save the token in your repository secrets
-        #policy_token: $
+          policy_token: ${{ secrets.GRAFANA_PLUGIN_SIGNING_TOKEN }}
         # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
         #grafana_token: $


### PR DESCRIPTION
The plugin was not signed therefore not reviewed/published by Grafana. Export the policy token secret variable to sign the plugin during the release workflow.